### PR TITLE
Changed script-link to public available Client-SDK

### DIFF
--- a/custom-widget-sdk/index.html
+++ b/custom-widget-sdk/index.html
@@ -7,7 +7,7 @@
         crossorigin="anonymous"></script>
     <title>LivePerson SDK client example 4</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="https://qtvr-wap11.dev.lprnd.net/webagent/client-SDK.min.js"></script>
+    <script src="https://lpcdn.lpsnmedia.net/webagent/client-SDK.min.js"></script>
     <script src="./script.js"></script>
 
     <style>


### PR DESCRIPTION
Reference Client-SDK is non-public, updated URL to the public location.